### PR TITLE
유저 조회 기능 및 가입시 이메일 중복 검증 구현

### DIFF
--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/application/JoinUserCommand.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/application/JoinUserCommand.kt
@@ -4,7 +4,7 @@ import com.waveofmymind.user.domain.User
 
 data class JoinUserCommand(
     private val name: String,
-    private val email: String,
+    val email: String,
     private val password: String
 ) {
     fun toEntity() = User.from(

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/application/UserReader.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/application/UserReader.kt
@@ -1,0 +1,19 @@
+package com.waveofmymind.user.application
+
+import com.waveofmymind.user.domain.UserJpaRepository
+import com.waveofmymind.user.presentation.UserResponse
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class UserReader(
+    private val userRepository: UserJpaRepository
+) {
+
+    fun getUser(id: Long): UserResponse {
+        val user = userRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("유저를 찾지 못했습니다.")
+        return UserResponse.from(user.id, user.name, user.email)
+    }
+}

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/application/UserReader.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/application/UserReader.kt
@@ -1,5 +1,6 @@
 package com.waveofmymind.user.application
 
+import com.waveofmymind.user.domain.User
 import com.waveofmymind.user.domain.UserJpaRepository
 import com.waveofmymind.user.presentation.UserResponse
 import org.springframework.data.repository.findByIdOrNull
@@ -15,5 +16,9 @@ class UserReader(
     fun getUser(id: Long): UserResponse {
         val user = userRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("유저를 찾지 못했습니다.")
         return UserResponse.from(user.id, user.name, user.email)
+    }
+
+    fun getUserByEmail(email: String): User? {
+        return userRepository.findByEmail(email)
     }
 }

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/application/UserService.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/application/UserService.kt
@@ -1,0 +1,25 @@
+package com.waveofmymind.user.application
+
+import com.waveofmymind.user.presentation.UserResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserService(
+    private val userReader: UserReader,
+    private val userWriter: UserWriter
+) {
+
+    @Transactional
+    fun joinUser(command: JoinUserCommand) {
+        userReader.getUserByEmail(command.email)?.let {
+            throw IllegalArgumentException("이미 존재하는 이메일입니다.")
+        }
+        userWriter.joinUser(command)
+    }
+
+    @Transactional(readOnly = true)
+    fun getUser(id: Long): UserResponse {
+        return userReader.getUser(id)
+    }
+}

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/domain/User.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/domain/User.kt
@@ -13,10 +13,10 @@ import org.jetbrains.annotations.NotNull
 class User(
 
     @NotNull
-    private val name: String,
+    val name: String,
 
     @NotNull
-    private val email: String,
+    val email: String,
 
     @NotNull
     private val password: String,
@@ -24,7 +24,7 @@ class User(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
-    private val id: Long = 0L
+    val id: Long = 0L
 ) {
     companion object {
         fun from(name: String, email: String, password: String) = User(name, email, password)

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/domain/UserJpaRepository.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/domain/UserJpaRepository.kt
@@ -2,4 +2,6 @@ package com.waveofmymind.user.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserJpaRepository : JpaRepository<User, Long>
+interface UserJpaRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
+}

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/presentation/UserController.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/presentation/UserController.kt
@@ -1,7 +1,10 @@
 package com.waveofmymind.user.presentation
 
+import com.waveofmymind.user.application.UserReader
 import com.waveofmymind.user.application.UserWriter
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -11,12 +14,18 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/users")
 class UserController(
-    private val userWriter: UserWriter
+    private val userWriter: UserWriter,
+    private val userReader: UserReader
 ) {
 
     @PostMapping("/join")
     @ResponseStatus(HttpStatus.CREATED)
     fun join(@RequestBody request: JoinUserRequest) {
         userWriter.joinUser(request.toCommand())
+    }
+
+    @GetMapping("/{userId}")
+    fun getUser(@PathVariable userId: Long): UserResponse {
+        return userReader.getUser(userId)
     }
 }

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/presentation/UserController.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/presentation/UserController.kt
@@ -1,7 +1,6 @@
 package com.waveofmymind.user.presentation
 
-import com.waveofmymind.user.application.UserReader
-import com.waveofmymind.user.application.UserWriter
+import com.waveofmymind.user.application.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -14,18 +13,17 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/users")
 class UserController(
-    private val userWriter: UserWriter,
-    private val userReader: UserReader
+    private val userService: UserService
 ) {
 
     @PostMapping("/join")
     @ResponseStatus(HttpStatus.CREATED)
     fun join(@RequestBody request: JoinUserRequest) {
-        userWriter.joinUser(request.toCommand())
+        userService.joinUser(request.toCommand())
     }
 
     @GetMapping("/{userId}")
     fun getUser(@PathVariable userId: Long): UserResponse {
-        return userReader.getUser(userId)
+        return userService.getUser(userId)
     }
 }

--- a/fintech-user/src/main/kotlin/com/waveofmymind/user/presentation/UserResponse.kt
+++ b/fintech-user/src/main/kotlin/com/waveofmymind/user/presentation/UserResponse.kt
@@ -1,0 +1,12 @@
+package com.waveofmymind.user.presentation
+
+data class UserResponse(
+    val id: Long,
+    val name: String,
+    val email: String
+) {
+    companion object {
+        @JvmStatic
+        fun from(id: Long, name: String, email: String) = UserResponse(id, name, email)
+    }
+}


### PR DESCRIPTION
- 이메일로 중복 가입에 대한 검증 여부를 처리한다.
    - 이메일로 조회시 레코드가 있을 경우 예외를 반환한다.
- userId(= PK)로 유저를 조회할 수 있다.